### PR TITLE
adding mix user functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ optional arguments:
   -h, --help            show this help message and exit
   -k API_KEY, --api-key API_KEY
   -u USER, --user USER
+  -m USER, --mix_user USER
   -c, --chaos
   --debug
 ```

--- a/sav.py
+++ b/sav.py
@@ -16,8 +16,9 @@ import os
 parser = argparse.ArgumentParser()
 parser.add_argument('topic')
 parser.add_argument('-k', '--api-key', required=True)
-parser.add_argument('-u', '--user', default='seb')
-parser.add_argument('-m', '--mix_user', default='dav')
+parser.add_argument('-u', '--user', default='sav')
+parser.add_argument('-m', '--mix_user_1', default='seb')
+parser.add_argument('-n', '--mix_user_2', default='dav')
 parser.add_argument('-c', '--chaos', action='store_true')
 parser.add_argument('--debug', action='store_true')
 settings = parser.parse_args()
@@ -96,8 +97,8 @@ def get_text(name):
 #     return '. '.join(valid_tweets)
 
 def get_post():
-    seb_model = markovify.Text(get_text(settings.user))
-    dav_model = markovify.Text(get_text(settings.mix_user))
+    seb_model = markovify.Text(get_text(settings.mix_user_1))
+    dav_model = markovify.Text(get_text(settings.mix_user_2))
 
     # Unused Twitter code
     # twitter_model = markovify.Text(get_tweets(''))

--- a/sav.py
+++ b/sav.py
@@ -16,7 +16,8 @@ import os
 parser = argparse.ArgumentParser()
 parser.add_argument('topic')
 parser.add_argument('-k', '--api-key', required=True)
-parser.add_argument('-u', '--user', default='sav')
+parser.add_argument('-u', '--user', default='seb')
+parser.add_argument('-m', '--mix_user', default='dav')
 parser.add_argument('-c', '--chaos', action='store_true')
 parser.add_argument('--debug', action='store_true')
 settings = parser.parse_args()
@@ -95,8 +96,8 @@ def get_text(name):
 #     return '. '.join(valid_tweets)
 
 def get_post():
-    seb_model = markovify.Text(get_text('seb'))
-    dav_model = markovify.Text(get_text('dav'))
+    seb_model = markovify.Text(get_text(settings.user))
+    dav_model = markovify.Text(get_text(settings.mix_user))
 
     # Unused Twitter code
     # twitter_model = markovify.Text(get_tweets(''))


### PR DESCRIPTION
Adding ability to choose the 'mix user' , a source that is somebody besides `dav`

Note that as written, this changes the default behavior to use `USER`, instead of `seb`, as the source.

Probably this should be split into a third option `-n`

But I wanted to run the pull request by you to discuss design defaults of how to gracefully use `-u`, `-m`, and `-n`